### PR TITLE
Camera re-connection logic

### DIFF
--- a/include/openni2_camera/openni2_driver.h
+++ b/include/openni2_camera/openni2_driver.h
@@ -85,6 +85,7 @@ private:
 
   void advertiseROSTopics();
 
+  void monitorConnection(const ros::TimerEvent& event);
   void colorConnectCb();
   void depthConnectCb();
   void irConnectCb();
@@ -104,6 +105,9 @@ private:
   void setColorVideoMode(const OpenNI2VideoMode& color_video_mode);
   void setDepthVideoMode(const OpenNI2VideoMode& depth_video_mode);
 
+  int extractBusID(const std::string& uri) const;
+  bool isConnected() const;
+
   ros::NodeHandle& nh_;
   ros::NodeHandle& pnh_;
 
@@ -111,6 +115,7 @@ private:
   boost::shared_ptr<OpenNI2Device> device_;
 
   std::string device_id_;
+  int bus_id_;
 
   /** \brief get_serial server*/
   ros::ServiceServer get_serial_server;
@@ -126,6 +131,9 @@ private:
   image_transport::CameraPublisher pub_depth_raw_;
   image_transport::CameraPublisher pub_ir_;
   ros::Publisher pub_projector_info_;
+
+  // timer object
+  ros::Timer timer_;
 
   /** \brief Camera info manager objects. */
   boost::shared_ptr<camera_info_manager::CameraInfoManager> color_info_manager_, ir_info_manager_;

--- a/include/openni2_camera/openni2_driver.h
+++ b/include/openni2_camera/openni2_driver.h
@@ -117,6 +117,9 @@ private:
   std::string device_id_;
   int bus_id_;
 
+  /** \brief indicates if reconnect logic is enabled. */
+  bool enable_reconnect_;
+
   /** \brief get_serial server*/
   ros::ServiceServer get_serial_server;
 
@@ -132,7 +135,7 @@ private:
   image_transport::CameraPublisher pub_ir_;
   ros::Publisher pub_projector_info_;
 
-  // timer object
+  /** \brief timer for connection monitoring thread */
   ros::Timer timer_;
 
   /** \brief Camera info manager objects. */


### PR DESCRIPTION
This is  partial fix for https://github.com/ros-drivers/openni2_camera/issues/36.

This fix addresses any disconnect/reconnect where the camera is recognized by the `OpenNI2::DeviceManager` (i.e the following message: `[ INFO] [1504148886.334244977]: Device "1d27/0601@1/23" found.` is posted).  Sometimes the USB driver itself fails to recognize the camera.  This scenario cannot be recovered using the changes in this fix.

This PR includes the follow "issues":
 - Monitoring thread runs continuously, instead of being event driven as suggested in https://github.com/ros-drivers/openni2_camera/issues/36 (won't fix)
 - Connection checking assumes only a single camera is attached to each bus (instead of comparing camera serial numbers to be certain when a specific camera is re-connected) (add issue)
 - Re-connection allowed when auto exposure/white balance disabled.  This should only be allowed when the exposure has been set to non-zero.  This requires this [issue](https://github.com/ros-drivers/openni2_camera/issues/51) be addressed. (add issue, might fix)

Due to the potential open issues, this PR should only be merged locally.


