### PR TITLE
Serial number (unique) is now used for camera name instead of camera ID (not unique)

### DIFF
--- a/src/openni2_driver.cpp
+++ b/src/openni2_driver.cpp
@@ -140,15 +140,23 @@ void OpenNI2Driver::advertiseROSTopics()
 
   // The camera names are set to [rgb|depth]_[serial#], e.g. depth_B00367707227042B.
   // camera_info_manager substitutes this for ${NAME} in the URL.
-  std::string serial_number = device_->getStringID();
-  std::string color_name, ir_name;
+  std::string serial_number, string_id;
+  std::string color_name, ir_name, color_cal_name, ir_cal_name;
 
-  color_name = "rgb_"   + serial_number;
-  ir_name  = "depth_" + serial_number;
+  string_id = device_->getStringID();
+  serial_number = device_manager_->getSerial(device_->getUri());
+
+  color_name = "rgb_"   + string_id;
+  ir_name    = "depth_" + string_id;
+
+  ROS_INFO_STREAM("THIS IS THE STRING_ID: " << string_id);
+
+  color_cal_name = color_info_url_ + "/" + serial_number + "_rgb.yaml";
+  ir_cal_name    = ir_info_url_    + "/" + serial_number + "_ir.yaml";
 
   // Load the saved calibrations, if they exist
-  color_info_manager_ = boost::make_shared<camera_info_manager::CameraInfoManager>(color_nh, color_name, color_info_url_);
-  ir_info_manager_  = boost::make_shared<camera_info_manager::CameraInfoManager>(ir_nh,  ir_name,  ir_info_url_);
+  color_info_manager_ = boost::make_shared<camera_info_manager::CameraInfoManager>(color_nh, color_name, color_cal_name);
+  ir_info_manager_  = boost::make_shared<camera_info_manager::CameraInfoManager>(ir_nh,  ir_name,  ir_cal_name);
 
   get_serial_server = nh_.advertiseService("get_serial", &OpenNI2Driver::getSerialCb,this);
 

--- a/src/openni2_driver.cpp
+++ b/src/openni2_driver.cpp
@@ -140,23 +140,18 @@ void OpenNI2Driver::advertiseROSTopics()
 
   // The camera names are set to [rgb|depth]_[serial#], e.g. depth_B00367707227042B.
   // camera_info_manager substitutes this for ${NAME} in the URL.
-  std::string serial_number, string_id;
-  std::string color_name, ir_name, color_cal_name, ir_cal_name;
+  std::string serial_number;
+  std::string color_name, ir_name;
 
-  string_id = device_->getStringID();
   serial_number = device_manager_->getSerial(device_->getUri());
+  ROS_INFO_STREAM("Loading camera info manager, using camera serial number: " << serial_number);
 
-  color_name = "rgb_"   + string_id;
-  ir_name    = "depth_" + string_id;
-
-  ROS_INFO_STREAM("THIS IS THE STRING_ID: " << string_id);
-
-  color_cal_name = color_info_url_ + "/" + serial_number + "_rgb.yaml";
-  ir_cal_name    = ir_info_url_    + "/" + serial_number + "_ir.yaml";
+  color_name = serial_number + "_rgb";
+  ir_name    = serial_number + "_ir";
 
   // Load the saved calibrations, if they exist
-  color_info_manager_ = boost::make_shared<camera_info_manager::CameraInfoManager>(color_nh, color_name, color_cal_name);
-  ir_info_manager_  = boost::make_shared<camera_info_manager::CameraInfoManager>(ir_nh,  ir_name,  ir_cal_name);
+  color_info_manager_ = boost::make_shared<camera_info_manager::CameraInfoManager>(color_nh, color_name, color_info_url_);
+  ir_info_manager_  = boost::make_shared<camera_info_manager::CameraInfoManager>(ir_nh,  ir_name,  ir_info_url_);
 
   get_serial_server = nh_.advertiseService("get_serial", &OpenNI2Driver::getSerialCb,this);
 


### PR DESCRIPTION
The previous method of using the camera ID string (`depth_PS1080_PrimeSense`/`rgb_PS1080_PrimeSense`) did not result in a unique name, which could be tied back to calibration.  I changed the method to use the serial number (unique).  In addition, I changed the naming convention to match the PlusOne calibration file naming.